### PR TITLE
Configurable connection string support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/kubernetes-sigs/service-catalog v0.2.1
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pivotal-cf/brokerapi v5.1.0+incompatible
-	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 	github.com/tidwall/pretty v1.0.0 // indirect
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,7 @@ github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzu
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/pkg/atlas/cluster.go
+++ b/pkg/atlas/cluster.go
@@ -38,8 +38,9 @@ type Cluster struct {
 	ProviderSettings         *ProviderSettings `json:"providerSettings"`
 
 	// Read-only attributes
-	StateName  string `json:"stateName,omitempty"`
-	SrvAddress string `json:"srvAddress,omitempty"`
+	StateName           string `json:"stateName,omitempty"`
+	SrvAddress          string `json:"srvAddress,omitempty"`
+	MongoURIWithOptions string `json:"mongoURIWithOptions,omitempty"`
 }
 
 // AutoScalingConfig represents the autoscaling settings for a cluster.

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -12,8 +12,10 @@ import (
 )
 
 var (
-	testServiceID = "aosb-cluster-service-aws"
-	testPlanID    = "aosb-cluster-plan-aws-m10"
+	testServiceID       = "aosb-cluster-service-aws"
+	testPlanID          = "aosb-cluster-plan-aws-m10"
+	srvAddress          = "mongodb+srv://host"
+	mongoURIWithOptions = "mongodb://shard-0.host:27017,shard-1.host:27017,shard-2.host:27017/?ssl=true&authSource=admin&replicaSet=shard"
 )
 
 type MockAtlasClient struct {
@@ -27,6 +29,8 @@ func (m MockAtlasClient) CreateCluster(cluster atlas.Cluster) (*atlas.Cluster, e
 	}
 
 	cluster.StateName = atlas.ClusterStateCreating
+	cluster.SrvAddress = srvAddress
+	cluster.MongoURIWithOptions = mongoURIWithOptions
 
 	m.Clusters[cluster.Name] = &cluster
 

--- a/pkg/broker/instance_operations_test.go
+++ b/pkg/broker/instance_operations_test.go
@@ -157,6 +157,8 @@ func TestProvisionParams(t *testing.T) {
 			EncryptEBSVolume: true,
 			VolumeType:       "STANDARD",
 		},
+		SrvAddress:          srvAddress,
+		MongoURIWithOptions: mongoURIWithOptions,
 	}
 
 	cluster := client.Clusters[instanceID]


### PR DESCRIPTION
# Configurable connection string support

Allow ServiceBinding to produce a configurable connection string URL.

## Background

ServiceBinding creates a Kubernetes Secret with 3 fields: `uri`, `username`, and `password`. If we run applications that require fully qualified [MongoDB connections string URI](https://docs.mongodb.com/manual/reference/connection-string/) this is not sufficient.

## Proposal

* Enable `ServiceBinding` to produce the `connection_string` field (in addition to `uri`, `username`, and `password`).
* Add `connectionString` parameter to `ServiceBinding` spec parameters to make the `connection_string` configurable.

## Documentation

After success binding, a Kubernetes Secret containing connection details has a `connection_string` field. By default it contains a connection string URI in the [DNS Seedlist Connection Format](https://docs.mongodb.com/manual/reference/connection-string/#connections-dns-seedlist) with credentials: e.g. `mongodb+srv://username:password@host`. The connections string can be configured through `connectionString` parameter of `ServiceBinding` resource's spec.

| Name            | Type                | Default | Description                                                             |
|-----------------|---------------------|---------|-------------------------------------------------------------------------|
| skipCredentials | bool                | false   | Controlls whether credentials should be included in the URI             |
| database        | string              | ''      | Database name porting of the connection string URI                      |
| format          | 'standard' or 'srv' | 'srv'   | Scheme portion of the connection string URI: `mongodb` or `mongodb+srv` |
| options         | list                | []      | Options portion of the connection string URI                            |

Example `ServiceBinding` resource spec:

```yaml
apiVersion: servicecatalog.k8s.io/v1beta1
kind: ServiceBinding
metadata:
  name: atlas-cluster-binding
spec:
  instanceRef:
    name: atlas-cluster-instance
  parameters:
    user:
      roles:
      ...
    connectionString:
      skipCredentials: false
      database: test
      format: standard
      options:
        connectTimeoutMS: 1000
        tlsAllowInvalidCertificates: true
        w: "majority"
```